### PR TITLE
Initial Lion Support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ PREFIX=/usr/local/git
 # Undefine to not use sudo
 SUDO=sudo
 
-echo "Building GIT_VERSION $GIT_VERSION with arch $ARCH"
+echo "Building GIT_VERSION $GIT_VERSION with arch $HOSTTYPE"
 
 $SUDO mv $PREFIX{,_`date +%s`}
 
@@ -26,8 +26,8 @@ pushd git_build
         mv Makefile_head Makefile
 
 	# Make fat binaries with ppc/32 bit/64 bit
-        CFLAGS="-mmacosx-version-min=10.6 -isysroot /Developer/SDKs/MacOSX10.6.sdk -arch $ARCH"
-        LDFLAGS="-mmacosx-version-min=10.6 -isysroot /Developer/SDKs/MacOSX10.6.sdk -arch $ARCH"
+        CFLAGS="-mmacosx-version-min=10.6 -isysroot /Developer/SDKs/MacOSX10.6.sdk -arch $HOSTTYPE"
+        LDFLAGS="-mmacosx-version-min=10.6 -isysroot /Developer/SDKs/MacOSX10.6.sdk -arch $HOSTTYPE"
         make -j32 CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" prefix="$PREFIX" all
         make -j32 CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" prefix="$PREFIX" strip
         $SUDO make -j32 CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" prefix="$PREFIX" install


### PR DESCRIPTION
I'm ultimately not sure where the use of the ARCH variable came from, because it didn't exist on my systems. Looking around an Intel Mac mini still on 10.6 and the Intel iMac on 10.7 I'm currently using, I found that the HOSTTYPE variable is set appropriate in the environment to either i386 or x86_64. I initially tried to use the arch command's output, but that appears to return i386 no matter what, otherwise ppc if that is the processor architecture in use. Pending some testing, this change appears to work well for any architecture, on Snow Lepord, or Lion, and has the chance to work very well outside of those two OSes.
