### PR TITLE
Updated grep/sed regexp version for new git-scm.com website

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 . env.sh
 
 if [ "`uname`" == "Darwin" ]; then sed_regexp="-E"; else sed_regexp="-r"; fi 
-GIT_VERSION="${1:-`curl http://git-scm.com/ 2>&1 | grep "<div id=\"ver\">" | sed $sed_regexp 's/^.+>v([0-9.]+)<.+$/\1/'`}"
+GIT_VERSION="${1:-`curl http://git-scm.com/ 2>&1 | grep "<span class='version'>" | sed $sed_regexp 's/^.+>([0-9.]+)<.+$/\1/'`}"
 PREFIX=/usr/local/git
 # Undefine to not use sudo
 SUDO=sudo


### PR DESCRIPTION
Just a minor change to allow git_osx_installer to retrieve the version tag.
