### PR TITLE
git-prompt.sh is not copied correctly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,7 @@ pushd git_build
         # contrib
         $SUDO mkdir -p $PREFIX/contrib/completion
         $SUDO cp contrib/completion/git-completion.bash $PREFIX/contrib/completion/
+        $SUDO cp contrib/completion/git-prompt.sh $PREFIX/contrib/completion/
         $SUDO cp perl/private-Error.pm $PREFIX/lib/perl5/site_perl/Error.pm
     popd
     


### PR DESCRIPTION
In git 1.7.12 part of the git-completion.bash script was split into git-prompt.sh in commit https://github.com/git/git/commit/af31a456b4cd38f2630ed8e556e23954f806a3cc

This file should be copied over like git-completion.bash
