### PR TITLE
pkgutil now correctly forgets receipts

### DIFF
--- a/Disk Image/uninstall.sh
+++ b/Disk Image/uninstall.sh
@@ -9,7 +9,7 @@ if [ "$response" == "yes" ]; then
   sudo rm -rf /usr/local/git/
   sudo rm /etc/paths.d/git
   sudo rm /etc/manpaths.d/git
-  sudo pkgutil --forget --pkgs=GitOSX\.Installer\.git[A-Za-z0-9]*\.[a-z]*.pkg
+  pkgutil --packages | grep GitOSX.Installer | xargs -I {} sudo pkgutil --forget {}
   echo "Uninstalled"
 else
   echo "Aborted"


### PR DESCRIPTION
Hi.. this fixes the `pkgutil --forget` uninstall operation on MacOSX 10.8.4.
