### PR TITLE
Fix building git on mac + update git to 2.11.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ OSX_VERSION := 10.6
 SDK_PATH := $(shell bin/find-dir /Developer/SDKs/MacOSX$(OSX_VERSION).sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(OSX_VERSION).sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform)
 TARGET_FLAGS := -mmacosx-version-min=$(OSX_VERSION) -isysroot $(SDK_PATH) -DMACOSX_DEPLOYMENT_TARGET=$(OSX_VERSION)
 
+VERSION := 2.11.0
+
 ifeq ("$(OSX_VERSION)", "10.6")
 OSX_NAME := Snow Leopard
 endif

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OSX_VERSION := 10.6
 SDK_PATH := $(shell bin/find-dir /Developer/SDKs/MacOSX$(OSX_VERSION).sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(OSX_VERSION).sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform)
 TARGET_FLAGS := -mmacosx-version-min=$(OSX_VERSION) -isysroot $(SDK_PATH) -DMACOSX_DEPLOYMENT_TARGET=$(OSX_VERSION)
 
-VERSION := 2.11.0
+#VERSION := 2.11.0
 
 ifeq ("$(OSX_VERSION)", "10.6")
 OSX_NAME := Snow Leopard
@@ -91,40 +91,40 @@ tmp/setup-verified: /usr/local/etc/xml/catalog /usr/local/bin/xmlto /usr/local/b
 
 setup: tmp/setup-verified
 
-$(DESTDIR)$(GIT_PREFIX)/VERSION-$(VERSION)-$(BUILD_CODE):
+$(DESTDIR)$(GIT_PREFIX)/VERSION-$(GIT_VERSION)-$(BUILD_CODE):
 	[ -d $(DESTDIR)$(GIT_PREFIX) ] && $(SUDO) rm -rf $(DESTDIR) || echo ok
-	rm -f $(BUILD_DIR)/git-$(VERSION)/osx-installed*
+	rm -f $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed*
 	mkdir -p $(DESTDIR)$(GIT_PREFIX)
 	touch $@
 
 build/%.tar.gz:
 	mkdir -p build
-	curl -oL build/$*-$(VERSION).tar.gz.working "$(DOWNLOAD_LOCATION)/$*-$(VERSION).tar.gz"
-	mv build/$*-$(VERSION).tar.gz.working build/$*-$(VERSION).tar.gz
+	curl -oL build/$*.tar.gz.working "$(DOWNLOAD_LOCATION)/$*.tar.gz"
+	mv build/$*.tar.gz.working build/$*.tar.gz
 
-$(BUILD_DIR)/git-$(VERSION)/Makefile: build/git-$(VERSION).tar.gz
+$(BUILD_DIR)/git-$(GIT_VERSION)/Makefile: build/git-$(GIT_VERSION).tar.gz
 	mkdir -p $(BUILD_DIR)
-	tar xzf build/git-$(VERSION).tar.gz -C $(BUILD_DIR)
+	tar xzf build/git-$(GIT_VERSION).tar.gz -C $(BUILD_DIR)
 	touch $@
 
-$(BUILD_DIR)/git-$(VERSION)/osx-built: $(BUILD_DIR)/git-$(VERSION)/Makefile
-	cd $(BUILD_DIR)/git-$(VERSION); $(SUBMAKE) -j $(CORES) all strip
+$(BUILD_DIR)/git-$(GIT_VERSION)/osx-built: $(BUILD_DIR)/git-$(GIT_VERSION)/Makefile
+	cd $(BUILD_DIR)/git-$(GIT_VERSION); $(SUBMAKE) -j $(CORES) all strip
 	touch $@
 
-$(BUILD_DIR)/git-$(VERSION)/osx-built-keychain: $(BUILD_DIR)/git-$(VERSION)/Makefile
-	cd $(BUILD_DIR)/git-$(VERSION)/contrib/credential/osxkeychain; $(SUBMAKE) CFLAGS="$(CFLAGS) -g -O2 -Wall"
+$(BUILD_DIR)/git-$(GIT_VERSION)/osx-built-keychain: $(BUILD_DIR)/git-$(GIT_VERSION)/Makefile
+	cd $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/credential/osxkeychain; $(SUBMAKE) CFLAGS="$(CFLAGS) -g -O2 -Wall"
 	touch $@
 
 $(BUILD_DIR)/git-$(VERSION)/osx-built-subtree: $(BUILD_DIR)/git-$(VERSION)/Makefile | setup
-	cd $(BUILD_DIR)/git-$(VERSION)/contrib/subtree; $(SUBMAKE) XML_CATALOG_FILES="$(XML_CATALOG_FILES)" all git-subtree.1
+	cd $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/subtree; $(SUBMAKE) XML_CATALOG_FILES="$(XML_CATALOG_FILES)" all git-subtree.1
 	touch $@
 
-$(BUILD_DIR)/git-$(VERSION)/osx-installed-subtree: $(BUILD_DIR)/git-$(VERSION)/osx-built-subtree
+$(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-subtree: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-built-subtree
 	mkdir -p $(DESTDIR)
-	cd $(BUILD_DIR)/git-$(VERSION)/contrib/subtree; $(SUBMAKE) XML_CATALOG_FILES="$(XML_CATALOG_FILES)" install install-man
+	cd $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/subtree; $(SUBMAKE) XML_CATALOG_FILES="$(XML_CATALOG_FILES)" install install-man
 	touch $@
 
-$(BUILD_DIR)/git-$(VERSION)/osx-installed-assets: $(BUILD_DIR)/git-$(VERSION)/osx-installed-bin
+$(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-assets: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-bin
 	mkdir -p $(DESTDIR)$(GIT_PREFIX)/etc
 	cp assets/etc/gitconfig.default $(DESTDIR)$(GIT_PREFIX)/etc/gitconfig
 	cat assets/etc/gitconfig.osxkeychain >> $(DESTDIR)$(GIT_PREFIX)/etc/gitconfig
@@ -135,41 +135,41 @@ $(BUILD_DIR)/git-$(VERSION)/osx-installed-assets: $(BUILD_DIR)/git-$(VERSION)/os
 	for man in man1 man3 man5 man7; do mkdir -p $(DESTDIR)$(PREFIX)/share/man/$$man; (cd $(DESTDIR)$(PREFIX)/share/man/$$man; ln -sf ../../../git/share/man/$$man/* ./); done
 	touch $@
 
-$(BUILD_DIR)/git-$(VERSION)/osx-installed-bin: $(BUILD_DIR)/git-$(VERSION)/osx-built $(BUILD_DIR)/git-$(VERSION)/osx-built-keychain $(DESTDIR)$(GIT_PREFIX)/VERSION-$(VERSION)-$(BUILD_CODE)
-	cd $(BUILD_DIR)/git-$(VERSION); $(SUBMAKE) install
-	cp $(BUILD_DIR)/git-$(VERSION)/contrib/credential/osxkeychain/git-credential-osxkeychain $(DESTDIR)$(GIT_PREFIX)/bin/git-credential-osxkeychain
+$(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-bin: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-built $(BUILD_DIR)/git-$(VERSION)/osx-built-keychain $(DESTDIR)$(GIT_PREFIX)/VERSION-$(GIT_VERSION)-$(BUILD_CODE)
+	cd $(BUILD_DIR)/git-$(GIT_VERSION); $(SUBMAKE) install
+	cp $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/credential/osxkeychain/git-credential-osxkeychain $(DESTDIR)$(GIT_PREFIX)/bin/git-credential-osxkeychain
 	mkdir -p $(DESTDIR)$(GIT_PREFIX)/contrib/completion
-	cp $(BUILD_DIR)/git-$(VERSION)/contrib/completion/git-completion.bash $(DESTDIR)$(GIT_PREFIX)/contrib/completion/
-	cp $(BUILD_DIR)/git-$(VERSION)/contrib/completion/git-completion.zsh $(DESTDIR)$(GIT_PREFIX)/contrib/completion/
-	cp $(BUILD_DIR)/git-$(VERSION)/contrib/completion/git-prompt.sh $(DESTDIR)$(GIT_PREFIX)/contrib/completion/
+	cp $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/completion/git-completion.bash $(DESTDIR)$(GIT_PREFIX)/contrib/completion/
+	cp $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/completion/git-completion.zsh $(DESTDIR)$(GIT_PREFIX)/contrib/completion/
+	cp $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/completion/git-prompt.sh $(DESTDIR)$(GIT_PREFIX)/contrib/completion/
 	# This is needed for Git-Gui, GitK
 	mkdir -p $(DESTDIR)$(GIT_PREFIX)/lib/perl5/site_perl
-	[ ! -f $(DESTDIR)$(GIT_PREFIX)/lib/perl5/site_perl/Error.pm ] && cp $(BUILD_DIR)/git-$(VERSION)/perl/private-Error.pm $(DESTDIR)$(GIT_PREFIX)/lib/perl5/site_perl/Error.pm || echo done
+	[ ! -f $(DESTDIR)$(GIT_PREFIX)/lib/perl5/site_perl/Error.pm ] && cp $(BUILD_DIR)/git-$(GIT_VERSION)/perl/private-Error.pm $(DESTDIR)$(GIT_PREFIX)/lib/perl5/site_perl/Error.pm || echo done
 	ruby UserScripts/symlink_git_hardlinks.rb $(DESTDIR)
 	touch $@
 
-$(BUILD_DIR)/git-$(VERSION)/osx-installed-man: build/git-manpages-$(VERSION).tar.gz $(BUILD_DIR)/git-$(VERSION)/osx-installed-bin
-	tar xzfo build/git-manpages-$(VERSION).tar.gz -C $(DESTDIR)$(GIT_PREFIX)/share/man
+$(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-man: build/git-manpages-$(GIT_VERSION).tar.gz $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-bin
+	tar xzfo build/git-manpages-$(GIT_VERSION).tar.gz -C $(DESTDIR)$(GIT_PREFIX)/share/man
 	touch $@
 
-$(BUILD_DIR)/git-$(VERSION)/osx-installed: $(BUILD_DIR)/git-$(VERSION)/osx-installed-bin $(BUILD_DIR)/git-$(VERSION)/osx-installed-man $(BUILD_DIR)/git-$(VERSION)/osx-installed-assets $(BUILD_DIR)/git-$(VERSION)/osx-installed-subtree
+$(BUILD_DIR)/git-$(VERSION)/osx-installed: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-bin $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-man $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-assets $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-subtree
 	$(SUDO) chown -R root:wheel $(DESTDIR)$(GIT_PREFIX)
 	find $(DESTDIR)$(GIT_PREFIX) -type d -exec chmod ugo+rx {} \;
 	find $(DESTDIR)$(GIT_PREFIX) -type f -exec chmod ugo+r {} \;
 	touch $@
 
-$(BUILD_DIR)/git-$(VERSION)/osx-built-assert-$(ARCH_CODE): $(BUILD_DIR)/git-$(VERSION)/osx-built
+$(BUILD_DIR)/git-$(VERSION)/osx-built-assert-$(ARCH_CODE): $(BUILD_DIR)/git-$(GIT_VERSION)/osx-built
 ifeq ("$(ARCH_CODE)", "universal")
-	File $(BUILD_DIR)/git-$(VERSION)/git | grep "Mach-O universal binary with 2 architectures"
-	File $(BUILD_DIR)/git-$(VERSION)/contrib/credential/osxkeychain/git-credential-osxkeychain | grep "Mach-O universal binary with 2 architectures"
+	File $(BUILD_DIR)/git-$(GIT_VERSION)/git | grep "Mach-O universal binary with 2 architectures"
+	File $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/credential/osxkeychain/git-credential-osxkeychain | grep "Mach-O universal binary with 2 architectures"
 else
-	[ "$$(File $(BUILD_DIR)/git-$(VERSION)/git | cut -f 5 -d' ')" == "$(ARCH_CODE)" ]
-	[ "$$(File $(BUILD_DIR)/git-$(VERSION)/contrib/credential/osxkeychain/git-credential-osxkeychain | cut -f 5 -d' ')" == "$(ARCH_CODE)" ]
+	[ "$$(File $(BUILD_DIR)/git-$(GIT_VERSION)/git | cut -f 5 -d' ')" == "$(ARCH_CODE)" ]
+	[ "$$(File $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/credential/osxkeychain/git-credential-osxkeychain | cut -f 5 -d' ')" == "$(ARCH_CODE)" ]
 endif
 	touch $@
 
 
-disk-image/VERSION-$(VERSION)-$(ARCH_CODE)-$(OSX_CODE):
+disk-image/VERSION-$(GIT_VERSION)-$(ARCH_CODE)-$(OSX_CODE):
 	rm -f disk-image/*.pkg disk-image/VERSION-* disk-image/.DS_Store
 	touch "$@"
 
@@ -177,29 +177,29 @@ disk-image/git-$(VERSION)-$(BUILD_CODE).pkg: disk-image/VERSION-$(VERSION)-$(ARC
 	pkgbuild --identifier com.git.pkg --version $(VERSION) --root $(DESTDIR)$(PREFIX) --install-location $(PREFIX) --component-plist ./git-components.plist disk-image/git-$(VERSION)-$(BUILD_CODE).pkg
 
 git-%-$(BUILD_CODE).dmg: disk-image/git-%-$(BUILD_CODE).pkg
-	rm -f git-$(VERSION)-$(BUILD_CODE)*.dmg
-	hdiutil create git-$(VERSION)-$(BUILD_CODE).uncompressed.dmg -srcfolder disk-image -volname "Git $(VERSION) $(OSX_NAME) Intel $(ARCH)" -ov
-	hdiutil convert -format UDZO -o $@ git-$(VERSION)-$(BUILD_CODE).uncompressed.dmg
-	rm -f git-$(VERSION)-$(BUILD_CODE).uncompressed.dmg
+	rm -f git-$(GIT_VERSION)-$(BUILD_CODE)*.dmg
+	hdiutil create git-$(GIT_VERSION)-$(BUILD_CODE).uncompressed.dmg -srcfolder disk-image -volname "Git $(GIT_VERSION) $(OSX_NAME) Intel $(ARCH)" -ov
+	hdiutil convert -format UDZO -o $@ git-$(GIT_VERSION)-$(BUILD_CODE).uncompressed.dmg
+	rm -f git-$(GIT_VERSION)-$(BUILD_CODE).uncompressed.dmg
 
 tmp/deployed-%-$(BUILD_CODE): git-%-$(BUILD_CODE).dmg
 	mkdir -p tmp
-	scp git-$(VERSION)-$(BUILD_CODE).dmg timcharper@frs.sourceforge.net:/home/pfs/project/git-osx-installer | tee $@.working
+	scp git-$(GIT_VERSION)-$(BUILD_CODE).dmg timcharper@frs.sourceforge.net:/home/pfs/project/git-osx-installer | tee $@.working
 	mv $@.working $@
 
-package: disk-image/git-$(VERSION)-$(BUILD_CODE).pkg
-install-assets: $(BUILD_DIR)/git-$(VERSION)/osx-installed-assets
-install-bin: $(BUILD_DIR)/git-$(VERSION)/osx-installed-bin
-install-man: $(BUILD_DIR)/git-$(VERSION)/osx-installed-man
-install-subtree: $(BUILD_DIR)/git-$(VERSION)/osx-installed-subtree
+package: disk-image/git-$(GIT_VERSION)-$(BUILD_CODE).pkg
+install-assets: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-assets
+install-bin: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-bin
+install-man: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-man
+install-subtree: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-subtree
 
-install: $(BUILD_DIR)/git-$(VERSION)/osx-installed
+install: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed
 
-download: build/git-$(VERSION).tar.gz build/git-manpages-$(VERSION).tar.gz
+download: build/git-$(GIT_VERSION).tar.gz build/git-manpages-$(GIT_VERSION).tar.gz
 
-compile: $(BUILD_DIR)/git-$(VERSION)/osx-built $(BUILD_DIR)/git-$(VERSION)/osx-built-keychain $(BUILD_DIR)/git-$(VERSION)/osx-built-subtree
+compile: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-built $(BUILD_DIR)/git-$(GIT_VERSION)/osx-built-keychain $(BUILD_DIR)/git-$(GIT_VERSION)/osx-built-subtree
 
-deploy: tmp/deployed-$(VERSION)-$(BUILD_CODE)
+deploy: tmp/deployed-$(GIT_VERSION)-$(BUILD_CODE)
 
 tmp/deployed-readme: README.md
 	scp README.md timcharper@frs.sourceforge.net:/home/pfs/project/git-osx-installer | tee $@.working
@@ -209,14 +209,14 @@ readme: tmp/deployed-readme
 
 
 clean:
-	$(SUDO) rm -rf $(BUILD_DIR)/git-$(VERSION)/osx-* $(DESTDIR)
-	[ -d $(BUILD_DIR)/git-$(VERSION) ] && cd $(BUILD_DIR)/git-$(VERSION) && $(SUBMAKE) clean || echo done
-	[ -d $(BUILD_DIR)/git-$(VERSION)/contrib/credential/osxkeychain ] && cd $(BUILD_DIR)/git-$(VERSION)/contrib/credential/osxkeychain && $(SUBMAKE) clean || echo done
-	[ -d $(BUILD_DIR)/git-$(VERSION)/contrib/subtree ] && cd $(BUILD_DIR)/git-$(VERSION)/contrib/subtree && $(SUBMAKE) clean || echo done
+	$(SUDO) rm -rf $(BUILD_DIR)/git-$(GIT_VERSION)/osx-* $(DESTDIR)
+	[ -d $(BUILD_DIR)/git-$(GIT_VERSION) ] && cd $(BUILD_DIR)/git-$(GIT_VERSION) && $(SUBMAKE) clean || echo done
+	[ -d $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/credential/osxkeychain ] && cd $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/credential/osxkeychain && $(SUBMAKE) clean || echo done
+	[ -d $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/subtree ] && cd $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/subtree && $(SUBMAKE) clean || echo done
 
 reinstall:
 	$(SUDO) rm -rf /usr/local/git/VERSION-*
-	rm -f $(BUILD_DIR)/git-$(VERSION)/osx-installed*
+	rm -f $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed*
 	$(SUBMAKE) install
 
-image: git-$(VERSION)-$(BUILD_CODE).dmg
+image: git-$(GIT_VERSION)-$(BUILD_CODE).dmg

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ endif
 ifeq ("$(OSX_VERSION)", "10.11")
 OSX_NAME := El Capitan
 endif
+ifeq ("$(OSX_VERSION)", "10.12")
+OSX_NAME := Sierra
+endif
 
 OSX_CODE := $(shell echo "$(OSX_NAME)" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
 
@@ -94,8 +97,8 @@ $(DESTDIR)$(GIT_PREFIX)/VERSION-$(VERSION)-$(BUILD_CODE):
 
 build/%.tar.gz:
 	mkdir -p build
-	curl -o build/$*.tar.gz.working "$(DOWNLOAD_LOCATION)/$*.tar.gz"
-	mv build/$*.tar.gz.working build/$*.tar.gz
+	curl -oL build/$*-$(VERSION).tar.gz.working "$(DOWNLOAD_LOCATION)/$*-$(VERSION).tar.gz"
+	mv build/$*-$(VERSION).tar.gz.working build/$*-$(VERSION).tar.gz
 
 $(BUILD_DIR)/git-$(VERSION)/Makefile: build/git-$(VERSION).tar.gz
 	mkdir -p $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ $(DESTDIR)$(GIT_PREFIX)/VERSION-$(VERSION)-$(BUILD_CODE):
 
 build/%.tar.gz:
 	mkdir -p build
-	curl -oL build/$*.tar.gz.working "$(DOWNLOAD_LOCATION)/$*.tar.gz"
+	curl -o build/$*.tar.gz.working "$(DOWNLOAD_LOCATION)/$*.tar.gz"
 	mv build/$*.tar.gz.working build/$*.tar.gz
 
 $(BUILD_DIR)/git-$(VERSION)/Makefile: build/git-$(VERSION).tar.gz

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ OSX_VERSION := 10.6
 SDK_PATH := $(shell bin/find-dir /Developer/SDKs/MacOSX$(OSX_VERSION).sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(OSX_VERSION).sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform)
 TARGET_FLAGS := -mmacosx-version-min=$(OSX_VERSION) -isysroot $(SDK_PATH) -DMACOSX_DEPLOYMENT_TARGET=$(OSX_VERSION)
 
-#VERSION := 2.11.0
-
 ifeq ("$(OSX_VERSION)", "10.6")
 OSX_NAME := Snow Leopard
 endif
@@ -91,9 +89,9 @@ tmp/setup-verified: /usr/local/etc/xml/catalog /usr/local/bin/xmlto /usr/local/b
 
 setup: tmp/setup-verified
 
-$(DESTDIR)$(GIT_PREFIX)/VERSION-$(GIT_VERSION)-$(BUILD_CODE):
+$(DESTDIR)$(GIT_PREFIX)/VERSION-$(VERSION)-$(BUILD_CODE):
 	[ -d $(DESTDIR)$(GIT_PREFIX) ] && $(SUDO) rm -rf $(DESTDIR) || echo ok
-	rm -f $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed*
+	rm -f $(BUILD_DIR)/git-$(VERSION)/osx-installed*
 	mkdir -p $(DESTDIR)$(GIT_PREFIX)
 	touch $@
 
@@ -102,29 +100,29 @@ build/%.tar.gz:
 	curl -oL build/$*.tar.gz.working "$(DOWNLOAD_LOCATION)/$*.tar.gz"
 	mv build/$*.tar.gz.working build/$*.tar.gz
 
-$(BUILD_DIR)/git-$(GIT_VERSION)/Makefile: build/git-$(GIT_VERSION).tar.gz
+$(BUILD_DIR)/git-$(VERSION)/Makefile: build/git-$(VERSION).tar.gz
 	mkdir -p $(BUILD_DIR)
-	tar xzf build/git-$(GIT_VERSION).tar.gz -C $(BUILD_DIR)
+	tar xzf build/git-$(VERSION).tar.gz -C $(BUILD_DIR)
 	touch $@
 
-$(BUILD_DIR)/git-$(GIT_VERSION)/osx-built: $(BUILD_DIR)/git-$(GIT_VERSION)/Makefile
-	cd $(BUILD_DIR)/git-$(GIT_VERSION); $(SUBMAKE) -j $(CORES) all strip
+$(BUILD_DIR)/git-$(VERSION)/osx-built: $(BUILD_DIR)/git-$(VERSION)/Makefile
+	cd $(BUILD_DIR)/git-$(VERSION); $(SUBMAKE) -j $(CORES) all strip
 	touch $@
 
-$(BUILD_DIR)/git-$(GIT_VERSION)/osx-built-keychain: $(BUILD_DIR)/git-$(GIT_VERSION)/Makefile
-	cd $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/credential/osxkeychain; $(SUBMAKE) CFLAGS="$(CFLAGS) -g -O2 -Wall"
+$(BUILD_DIR)/git-$(VERSION)/osx-built-keychain: $(BUILD_DIR)/git-$(VERSION)/Makefile
+	cd $(BUILD_DIR)/git-$(VERSION)/contrib/credential/osxkeychain; $(SUBMAKE) CFLAGS="$(CFLAGS) -g -O2 -Wall"
 	touch $@
 
 $(BUILD_DIR)/git-$(VERSION)/osx-built-subtree: $(BUILD_DIR)/git-$(VERSION)/Makefile | setup
-	cd $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/subtree; $(SUBMAKE) XML_CATALOG_FILES="$(XML_CATALOG_FILES)" all git-subtree.1
+	cd $(BUILD_DIR)/git-$(VERSION)/contrib/subtree; $(SUBMAKE) XML_CATALOG_FILES="$(XML_CATALOG_FILES)" all git-subtree.1
 	touch $@
 
-$(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-subtree: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-built-subtree
+$(BUILD_DIR)/git-$(VERSION)/osx-installed-subtree: $(BUILD_DIR)/git-$(VERSION)/osx-built-subtree
 	mkdir -p $(DESTDIR)
-	cd $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/subtree; $(SUBMAKE) XML_CATALOG_FILES="$(XML_CATALOG_FILES)" install install-man
+	cd $(BUILD_DIR)/git-$(VERSION)/contrib/subtree; $(SUBMAKE) XML_CATALOG_FILES="$(XML_CATALOG_FILES)" install install-man
 	touch $@
 
-$(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-assets: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-bin
+$(BUILD_DIR)/git-$(VERSION)/osx-installed-assets: $(BUILD_DIR)/git-$(VERSION)/osx-installed-bin
 	mkdir -p $(DESTDIR)$(GIT_PREFIX)/etc
 	cp assets/etc/gitconfig.default $(DESTDIR)$(GIT_PREFIX)/etc/gitconfig
 	cat assets/etc/gitconfig.osxkeychain >> $(DESTDIR)$(GIT_PREFIX)/etc/gitconfig
@@ -135,41 +133,41 @@ $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-assets: $(BUILD_DIR)/git-$(GIT_VER
 	for man in man1 man3 man5 man7; do mkdir -p $(DESTDIR)$(PREFIX)/share/man/$$man; (cd $(DESTDIR)$(PREFIX)/share/man/$$man; ln -sf ../../../git/share/man/$$man/* ./); done
 	touch $@
 
-$(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-bin: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-built $(BUILD_DIR)/git-$(VERSION)/osx-built-keychain $(DESTDIR)$(GIT_PREFIX)/VERSION-$(GIT_VERSION)-$(BUILD_CODE)
-	cd $(BUILD_DIR)/git-$(GIT_VERSION); $(SUBMAKE) install
-	cp $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/credential/osxkeychain/git-credential-osxkeychain $(DESTDIR)$(GIT_PREFIX)/bin/git-credential-osxkeychain
+$(BUILD_DIR)/git-$(VERSION)/osx-installed-bin: $(BUILD_DIR)/git-$(VERSION)/osx-built $(BUILD_DIR)/git-$(VERSION)/osx-built-keychain $(DESTDIR)$(GIT_PREFIX)/VERSION-$(VERSION)-$(BUILD_CODE)
+	cd $(BUILD_DIR)/git-$(VERSION); $(SUBMAKE) install
+	cp $(BUILD_DIR)/git-$(VERSION)/contrib/credential/osxkeychain/git-credential-osxkeychain $(DESTDIR)$(GIT_PREFIX)/bin/git-credential-osxkeychain
 	mkdir -p $(DESTDIR)$(GIT_PREFIX)/contrib/completion
-	cp $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/completion/git-completion.bash $(DESTDIR)$(GIT_PREFIX)/contrib/completion/
-	cp $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/completion/git-completion.zsh $(DESTDIR)$(GIT_PREFIX)/contrib/completion/
-	cp $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/completion/git-prompt.sh $(DESTDIR)$(GIT_PREFIX)/contrib/completion/
+	cp $(BUILD_DIR)/git-$(VERSION)/contrib/completion/git-completion.bash $(DESTDIR)$(GIT_PREFIX)/contrib/completion/
+	cp $(BUILD_DIR)/git-$(VERSION)/contrib/completion/git-completion.zsh $(DESTDIR)$(GIT_PREFIX)/contrib/completion/
+	cp $(BUILD_DIR)/git-$(VERSION)/contrib/completion/git-prompt.sh $(DESTDIR)$(GIT_PREFIX)/contrib/completion/
 	# This is needed for Git-Gui, GitK
 	mkdir -p $(DESTDIR)$(GIT_PREFIX)/lib/perl5/site_perl
-	[ ! -f $(DESTDIR)$(GIT_PREFIX)/lib/perl5/site_perl/Error.pm ] && cp $(BUILD_DIR)/git-$(GIT_VERSION)/perl/private-Error.pm $(DESTDIR)$(GIT_PREFIX)/lib/perl5/site_perl/Error.pm || echo done
+	[ ! -f $(DESTDIR)$(GIT_PREFIX)/lib/perl5/site_perl/Error.pm ] && cp $(BUILD_DIR)/git-$(VERSION)/perl/private-Error.pm $(DESTDIR)$(GIT_PREFIX)/lib/perl5/site_perl/Error.pm || echo done
 	ruby UserScripts/symlink_git_hardlinks.rb $(DESTDIR)
 	touch $@
 
-$(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-man: build/git-manpages-$(GIT_VERSION).tar.gz $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-bin
-	tar xzfo build/git-manpages-$(GIT_VERSION).tar.gz -C $(DESTDIR)$(GIT_PREFIX)/share/man
+$(BUILD_DIR)/git-$(VERSION)/osx-installed-man: build/git-manpages-$(VERSION).tar.gz $(BUILD_DIR)/git-$(VERSION)/osx-installed-bin
+	tar xzfo build/git-manpages-$(VERSION).tar.gz -C $(DESTDIR)$(GIT_PREFIX)/share/man
 	touch $@
 
-$(BUILD_DIR)/git-$(VERSION)/osx-installed: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-bin $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-man $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-assets $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-subtree
+$(BUILD_DIR)/git-$(VERSION)/osx-installed: $(BUILD_DIR)/git-$(VERSION)/osx-installed-bin $(BUILD_DIR)/git-$(VERSION)/osx-installed-man $(BUILD_DIR)/git-$(VERSION)/osx-installed-assets $(BUILD_DIR)/git-$(VERSION)/osx-installed-subtree
 	$(SUDO) chown -R root:wheel $(DESTDIR)$(GIT_PREFIX)
 	find $(DESTDIR)$(GIT_PREFIX) -type d -exec chmod ugo+rx {} \;
 	find $(DESTDIR)$(GIT_PREFIX) -type f -exec chmod ugo+r {} \;
 	touch $@
 
-$(BUILD_DIR)/git-$(VERSION)/osx-built-assert-$(ARCH_CODE): $(BUILD_DIR)/git-$(GIT_VERSION)/osx-built
+$(BUILD_DIR)/git-$(VERSION)/osx-built-assert-$(ARCH_CODE): $(BUILD_DIR)/git-$(VERSION)/osx-built
 ifeq ("$(ARCH_CODE)", "universal")
-	File $(BUILD_DIR)/git-$(GIT_VERSION)/git | grep "Mach-O universal binary with 2 architectures"
-	File $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/credential/osxkeychain/git-credential-osxkeychain | grep "Mach-O universal binary with 2 architectures"
+	File $(BUILD_DIR)/git-$(VERSION)/git | grep "Mach-O universal binary with 2 architectures"
+	File $(BUILD_DIR)/git-$(VERSION)/contrib/credential/osxkeychain/git-credential-osxkeychain | grep "Mach-O universal binary with 2 architectures"
 else
-	[ "$$(File $(BUILD_DIR)/git-$(GIT_VERSION)/git | cut -f 5 -d' ')" == "$(ARCH_CODE)" ]
-	[ "$$(File $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/credential/osxkeychain/git-credential-osxkeychain | cut -f 5 -d' ')" == "$(ARCH_CODE)" ]
+	[ "$$(File $(BUILD_DIR)/git-$(VERSION)/git | cut -f 5 -d' ')" == "$(ARCH_CODE)" ]
+	[ "$$(File $(BUILD_DIR)/git-$(VERSION)/contrib/credential/osxkeychain/git-credential-osxkeychain | cut -f 5 -d' ')" == "$(ARCH_CODE)" ]
 endif
 	touch $@
 
 
-disk-image/VERSION-$(GIT_VERSION)-$(ARCH_CODE)-$(OSX_CODE):
+disk-image/VERSION-$(VERSION)-$(ARCH_CODE)-$(OSX_CODE):
 	rm -f disk-image/*.pkg disk-image/VERSION-* disk-image/.DS_Store
 	touch "$@"
 
@@ -177,29 +175,29 @@ disk-image/git-$(VERSION)-$(BUILD_CODE).pkg: disk-image/VERSION-$(VERSION)-$(ARC
 	pkgbuild --identifier com.git.pkg --version $(VERSION) --root $(DESTDIR)$(PREFIX) --install-location $(PREFIX) --component-plist ./git-components.plist disk-image/git-$(VERSION)-$(BUILD_CODE).pkg
 
 git-%-$(BUILD_CODE).dmg: disk-image/git-%-$(BUILD_CODE).pkg
-	rm -f git-$(GIT_VERSION)-$(BUILD_CODE)*.dmg
-	hdiutil create git-$(GIT_VERSION)-$(BUILD_CODE).uncompressed.dmg -srcfolder disk-image -volname "Git $(GIT_VERSION) $(OSX_NAME) Intel $(ARCH)" -ov
-	hdiutil convert -format UDZO -o $@ git-$(GIT_VERSION)-$(BUILD_CODE).uncompressed.dmg
-	rm -f git-$(GIT_VERSION)-$(BUILD_CODE).uncompressed.dmg
+	rm -f git-$(VERSION)-$(BUILD_CODE)*.dmg
+	hdiutil create git-$(VERSION)-$(BUILD_CODE).uncompressed.dmg -srcfolder disk-image -volname "Git $(VERSION) $(OSX_NAME) Intel $(ARCH)" -ov
+	hdiutil convert -format UDZO -o $@ git-$(VERSION)-$(BUILD_CODE).uncompressed.dmg
+	rm -f git-$(VERSION)-$(BUILD_CODE).uncompressed.dmg
 
 tmp/deployed-%-$(BUILD_CODE): git-%-$(BUILD_CODE).dmg
 	mkdir -p tmp
-	scp git-$(GIT_VERSION)-$(BUILD_CODE).dmg timcharper@frs.sourceforge.net:/home/pfs/project/git-osx-installer | tee $@.working
+	scp git-$(VERSION)-$(BUILD_CODE).dmg timcharper@frs.sourceforge.net:/home/pfs/project/git-osx-installer | tee $@.working
 	mv $@.working $@
 
-package: disk-image/git-$(GIT_VERSION)-$(BUILD_CODE).pkg
-install-assets: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-assets
-install-bin: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-bin
-install-man: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-man
-install-subtree: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed-subtree
+package: disk-image/git-$(VERSION)-$(BUILD_CODE).pkg
+install-assets: $(BUILD_DIR)/git-$(VERSION)/osx-installed-assets
+install-bin: $(BUILD_DIR)/git-$(VERSION)/osx-installed-bin
+install-man: $(BUILD_DIR)/git-$(VERSION)/osx-installed-man
+install-subtree: $(BUILD_DIR)/git-$(VERSION)/osx-installed-subtree
 
-install: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed
+install: $(BUILD_DIR)/git-$(VERSION)/osx-installed
 
-download: build/git-$(GIT_VERSION).tar.gz build/git-manpages-$(GIT_VERSION).tar.gz
+download: build/git-$(VERSION).tar.gz build/git-manpages-$(VERSION).tar.gz
 
-compile: $(BUILD_DIR)/git-$(GIT_VERSION)/osx-built $(BUILD_DIR)/git-$(GIT_VERSION)/osx-built-keychain $(BUILD_DIR)/git-$(GIT_VERSION)/osx-built-subtree
+compile: $(BUILD_DIR)/git-$(VERSION)/osx-built $(BUILD_DIR)/git-$(VERSION)/osx-built-keychain $(BUILD_DIR)/git-$(VERSION)/osx-built-subtree
 
-deploy: tmp/deployed-$(GIT_VERSION)-$(BUILD_CODE)
+deploy: tmp/deployed-$(VERSION)-$(BUILD_CODE)
 
 tmp/deployed-readme: README.md
 	scp README.md timcharper@frs.sourceforge.net:/home/pfs/project/git-osx-installer | tee $@.working
@@ -209,14 +207,14 @@ readme: tmp/deployed-readme
 
 
 clean:
-	$(SUDO) rm -rf $(BUILD_DIR)/git-$(GIT_VERSION)/osx-* $(DESTDIR)
-	[ -d $(BUILD_DIR)/git-$(GIT_VERSION) ] && cd $(BUILD_DIR)/git-$(GIT_VERSION) && $(SUBMAKE) clean || echo done
-	[ -d $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/credential/osxkeychain ] && cd $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/credential/osxkeychain && $(SUBMAKE) clean || echo done
-	[ -d $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/subtree ] && cd $(BUILD_DIR)/git-$(GIT_VERSION)/contrib/subtree && $(SUBMAKE) clean || echo done
+	$(SUDO) rm -rf $(BUILD_DIR)/git-$(VERSION)/osx-* $(DESTDIR)
+	[ -d $(BUILD_DIR)/git-$(VERSION) ] && cd $(BUILD_DIR)/git-$(VERSION) && $(SUBMAKE) clean || echo done
+	[ -d $(BUILD_DIR)/git-$(VERSION)/contrib/credential/osxkeychain ] && cd $(BUILD_DIR)/git-$(VERSION)/contrib/credential/osxkeychain && $(SUBMAKE) clean || echo done
+	[ -d $(BUILD_DIR)/git-$(VERSION)/contrib/subtree ] && cd $(BUILD_DIR)/git-$(VERSION)/contrib/subtree && $(SUBMAKE) clean || echo done
 
 reinstall:
 	$(SUDO) rm -rf /usr/local/git/VERSION-*
-	rm -f $(BUILD_DIR)/git-$(GIT_VERSION)/osx-installed*
+	rm -f $(BUILD_DIR)/git-$(VERSION)/osx-installed*
 	$(SUBMAKE) install
 
-image: git-$(GIT_VERSION)-$(BUILD_CODE).dmg
+image: git-$(VERSION)-$(BUILD_CODE).dmg

--- a/build_package_test_and_bundle.sh
+++ b/build_package_test_and_bundle.sh
@@ -7,7 +7,7 @@ rm -f Disk\ Image/*.pkg
 
 . ./env.sh
 
-GIT_VERSION=${1:-$(CURRENT-GIT-VERSION)}
+GIT_VERSION=${1:-$(current-git-version)}
 
 echo $GIT_VERSION
 

--- a/build_package_test_and_bundle.sh
+++ b/build_package_test_and_bundle.sh
@@ -18,4 +18,4 @@ echo "Testing the installer..."
 
 . test_installer.sh
 
-make OSX_VERSION=${OSX_VERSION:-10.9} VERSION=${GIT_VERSION} deploy
+make OSX_VERSION=${OSX_VERSION:-10.9} VERSION=${GIT_VERSION} GIT_VERSION=${GIT_VERSION} deploy

--- a/build_package_test_and_bundle.sh
+++ b/build_package_test_and_bundle.sh
@@ -18,4 +18,4 @@ echo "Testing the installer..."
 
 . test_installer.sh
 
-make OSX_VERSION=${OSX_VERSION:-10.9} VERSION_VERSION=${GIT_VERSION} deploy
+make OSX_VERSION=${OSX_VERSION:-10.9} VERSION=${GIT_VERSION} deploy

--- a/build_package_test_and_bundle.sh
+++ b/build_package_test_and_bundle.sh
@@ -7,7 +7,7 @@ rm -f Disk\ Image/*.pkg
 
 . ./env.sh
 
-GIT_VERSION=${1:-$(current-git-version)}
+GIT_VERSION=${1:-$(CURRENT-GIT-VERSION)}
 
 echo $GIT_VERSION
 
@@ -18,4 +18,4 @@ echo "Testing the installer..."
 
 . test_installer.sh
 
-make GIT_VERSION=$GIT_VERSION deploy
+make OSX_VERSION=${OSX_VERSION:-10.8} VERSION_VERSION=${GIT_VERSION} deploy

--- a/build_package_test_and_bundle.sh
+++ b/build_package_test_and_bundle.sh
@@ -18,4 +18,4 @@ echo "Testing the installer..."
 
 . test_installer.sh
 
-make OSX_VERSION=${OSX_VERSION:-10.8} VERSION_VERSION=${GIT_VERSION} deploy
+make OSX_VERSION=${OSX_VERSION:-10.9} VERSION_VERSION=${GIT_VERSION} deploy

--- a/env.sh
+++ b/env.sh
@@ -4,12 +4,11 @@ CURRENT_GIT_VERSION=""
 function current-git-version() {
   if [ -z "$CURRENT_GIT_VERSION" ]; then
     if [ "`uname`" == "Darwin" ]; then sed_regexp="-E"; else sed_regexp="-r"; fi
-    CURRENT_GIT_VERSION=$(curl http://git-scm.com/ 2>&1 | grep '<span class="version">' -A 1 | tail -n 1 | sed $sed_regexp 's/ *//')
+    CURRENT_GIT_VERSION=$(curl -L http://git-scm.com/ 2>&1 | grep '<span class="version">' -A 1 | tail -n 1 | sed $sed_regexp 's/ *//')
   fi
-  echo "$CURRENT_GIT_VERSION"
+  echo "${CURRENT_GIT_VERSION}"
 }
 
 function do-make() {
-  make OSX_VERSION=${OSX_VERSION:-10.9} VERSION=${GIT_VERSION:-$(current-git-version)} "${@}"
+  make OSX_VERSION=${OSX_VERSION:-10.9} VERSION=${GIT_VERSION:-${CURRENT_GIT_VERSION}} "${@}"
 }
-

--- a/test_installer.sh
+++ b/test_installer.sh
@@ -1,41 +1,42 @@
 #!/bin/sh
-find /usr/local/git > tmp/install_contents_before.txt
-echo "Testing..."
-sudo rm -rf /usr/local/git
+if [ -f "/usr/local/git" ]; then
+  find /usr/local/git > tmp/install_contents_before.txt
+  echo "Testing..."
+  sudo rm -rf /usr/local/git
 
-echo "OK - running the installer. Come back and press a key when you're done."
-open disk-image/git*.pkg 
+  echo "OK - running the installer. Come back and press a key when you're done."
+  open disk-image/git*.pkg 
 
-read -n 1
+  read -n 1
 
-for file in /usr/local/git/bin/git "/usr/local/git/share/git-gui/lib/Git Gui.app/Contents/Info.plist"; do
-  printf "'$file'"
-  if [ -f "$file" ]; then
-    echo " - exists"
+  for file in /usr/local/git/bin/git "/usr/local/git/share/git-gui/lib/Git Gui.app/Contents/Info.plist"; do
+    printf "'$file'"
+    if [ -f "$file" ]; then
+      echo " - exists"
+    else
+      echo " DOES NOT EXIST!"
+      for n in {1..20}; do
+        echo "FAIL FAIL FAIL"
+      done
+      exit 1
+    fi
+  done
+
+  find /usr/local/git > tmp/install_contents_after.txt
+
+  install_diff=$(diff tmp/install_contents_before.txt tmp/install_contents_after.txt)
+  if [ "$install_diff" == "" ]; then
+    echo "No files went missing!"
   else
-    echo " DOES NOT EXIST!"
-    for n in {1..20}; do
-      echo "FAIL FAIL FAIL"
-    done
+    echo "A FEW FILES WENT MISSING!
+  $install_diff"
     exit 1
   fi
-done
 
-find /usr/local/git > tmp/install_contents_after.txt
+  if (ls -alR /usr/local/git/* | grep `whoami`); then
+    echo "Some user-owned files exist!"
+    exit 1
+  fi
 
-install_diff=$(diff tmp/install_contents_before.txt tmp/install_contents_after.txt)
-if [ "$install_diff" == "" ]; then
-  echo "No files went missing!"
-else
-  echo "A FEW FILES WENT MISSING!
-$install_diff"
-  exit 1
+  echo "Success!"
 fi
-
-if (ls -alR /usr/local/git/* | grep `whoami`); then
-  echo "Some user-owned files exist!"
-  exit 1
-fi
-
-echo "Success!"
-


### PR DESCRIPTION
It seems to have failed because it was looking for git- but that does not exist. Instead look for git-(VERSION)

This also fixes support for mac OS X 10.12, all you have to do is change OSX_VERSION=10.9 to OSX_VERSION=10.12