### PR TITLE
Colocate download link with installer list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ precedence over this git. To overcome, do the following:
 
 Note, you will need to restart your shell after so-doing, as most shells (bash) cache command location resolution from PATH.
 
-## Which version should I download?
+## Which version should I [download](https://sourceforge.net/projects/git-osx-installer/files/)?
 
 If you are running:
 


### PR DESCRIPTION
Hello! Over in https://github.com/swcarpentry/workshop-template/issues/454 we direct new Git learners to your installer archive. Because the `If you are running` list could help them figure out which installer they need, we could direct them to it, if the download archive would be hyperlinked right beside/above it. Here's one minimum viable suggestion ;-)