### PR TITLE
Makefile: drop i386 architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,8 @@ endif
 OSX_CODE := $(shell echo "$(OSX_NAME)" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
 
 ARCH := Universal
-ARCH_CODE := $(shell echo "$(ARCH)" | tr '[:upper:]' '[:lower:]')
-ARCH_FLAGS_universal := -arch x86_64 -arch i386
-ARCH_FLAGS_i386 := -arch i386
+ARCH_CODE := universal
+ARCH_FLAGS_universal := -arch x86_64
 ARCH_FLAGS_x86_64 := -arch x86_64
 
 CFLAGS := $(TARGET_FLAGS) $(ARCH_FLAGS_${ARCH_CODE})
@@ -156,8 +155,8 @@ $(BUILD_DIR)/git-$(VERSION)/osx-installed: $(BUILD_DIR)/git-$(VERSION)/osx-insta
 
 $(BUILD_DIR)/git-$(VERSION)/osx-built-assert-$(ARCH_CODE): $(BUILD_DIR)/git-$(VERSION)/osx-built
 ifeq ("$(ARCH_CODE)", "universal")
-	File $(BUILD_DIR)/git-$(VERSION)/git | grep "Mach-O universal binary with 2 architectures"
-	File $(BUILD_DIR)/git-$(VERSION)/contrib/credential/osxkeychain/git-credential-osxkeychain | grep "Mach-O universal binary with 2 architectures"
+	File $(BUILD_DIR)/git-$(VERSION)/git
+	File $(BUILD_DIR)/git-$(VERSION)/contrib/credential/osxkeychain/git-credential-osxkeychain
 else
 	[ "$$(File $(BUILD_DIR)/git-$(VERSION)/git | cut -f 5 -d' ')" == "$(ARCH_CODE)" ]
 	[ "$$(File $(BUILD_DIR)/git-$(VERSION)/contrib/credential/osxkeychain/git-credential-osxkeychain | cut -f 5 -d' ')" == "$(ARCH_CODE)" ]

--- a/assets/uninstall.sh
+++ b/assets/uninstall.sh
@@ -12,7 +12,7 @@ else
   response="yes"
 fi
 
-if [ "$response" != "yes" ]; then
+if [ "$response" == "yes" ]; then
   # remove all of the symlinks we've created
   pkgutil --files com.git.pkg | grep bin | while read f; do
     if [ -L /usr/local/$f ]; then

--- a/assets/uninstall.sh
+++ b/assets/uninstall.sh
@@ -3,10 +3,16 @@ if [ ! -r "/usr/local/git" ]; then
   echo "Git doesn't appear to be installed via this installer.  Aborting"
   exit 1
 fi
-echo "This will uninstall git by removing /usr/local/git/, and symlinks"
-printf "Type 'yes' if you are sure you wish to continue: "
-read response
-if [ "$response" == "yes" ]; then
+
+if [ "$1" != "--yes" ]; then
+  echo "This will uninstall git by removing /usr/local/git/, and symlinks"
+  printf "Type 'yes' if you are sure you wish to continue: "
+  read response
+else
+  response="yes"
+fi
+
+if [ "$response" != "yes" ]; then
   # remove all of the symlinks we've created
   pkgutil --files com.git.pkg | grep bin | while read f; do
     if [ -L /usr/local/$f ]; then


### PR DESCRIPTION
We are using this repository to generate macOS builds for microsoft/git which is used by microsoft/vfsforgit and microsoft/scalar. We use Azure Pipelines to build the installers, but they recently deprecated the macOS 10.13 build agents. This caused our installer builds to start failing.

* [Failed build due to i386 architecture](https://dev.azure.com/gvfs/ci/_build/results?buildId=18356&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=59d5b2ff-d842-581a-8fe3-fd774adf34a7&l=247)
* [Successful build using this PR](https://dev.azure.com/gvfs/ci/_build/results?buildId=18362&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=59d5b2ff-d842-581a-8fe3-fd774adf34a7&l=245)

The i386 architecture seems to be removed, so we cannot build on recent versions of macOS like this.

**Note:** I'm new to this repo, so if there is a different workaround that would allow you to still build i386 executables on older macOS versions, then I'm happy to use that. Otherwise, we can also depend on my fork instead of this mainline version. Thanks!